### PR TITLE
Fix column specific transformer

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -71,6 +71,8 @@ export const configuration = {
 
   For `product` table, `description `column will get `This will be used`, and all other tables having `description` column will get `This will not be used`
 
+- `defaultTransformer`: if this is specified, then all of the columns not mentioned in the `columns` and `tables` will get this transformer. If this isn't specified, all of the undefined columns are left unchanged.
+
 You can go ahead and use something like [faker](https://www.npmjs.com/package/@faker-js/faker) or your own custom maskers for complex use cases.
 
 ## TroubleShooting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "pg-faker",
-  "version": "1.0.8",
+  "name": "pgfaker",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -13,13 +13,9 @@ class Parser {
   }
 
   verifyConfiguration() {
-    const { connectionUrl, defaultTransformer } = this.configuration;
+    const { connectionUrl } = this.configuration;
     if (!connectionUrl) {
       gracefulShutdown('connectionUrl is missing');
-    }
-
-    if (!defaultTransformer) {
-      gracefulShutdown('defaultTransformer  is missing');
     }
   }
 
@@ -44,10 +40,15 @@ class Parser {
   }
 
   applyTransform(value: string, table: string, column: string) {
+    const { defaultTransformer } = this.configuration;
     if (this.shouldTransform(table, column)) {
       const transformer = this.getTransformer((column));
       const changed = transformer(value);
       return changed;
+    }
+
+    if (!(defaultTransformer === null || defaultTransformer === undefined)) {
+      return defaultTransformer(value);
     }
 
     return value;
@@ -69,13 +70,10 @@ class Parser {
   }
 
   shouldTransform(table: string, column: string) {
-    if (this.isColumnMarked(column)) {
-      if (this.isTableMarked(table)) {
-        return this.isColumnMarkedInTable(column);
-      }
+    if (this.isColumnMarked(column) || this.isColumnMarkedInTable(column)) {
       return true;
     }
-    return this.isColumnMarkedInTable(column);
+    return false;
   }
 }
 


### PR DESCRIPTION
1. When both `columns` and `tables` specific transformers were given the column specific transformers were not getting applied. This is the fix for that.
2. `defaultTransformer` is now optional and also works as expected.
3. Updated the readme for `defaultTransformer`