### PR TITLE
Allow output to be dumped to STDOUT 

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
-# PG-Faker
+# PGFaker
 
 Tool for dumping/exporting your postgres database's table data with custom masking rules.
 
@@ -12,14 +12,14 @@ Currently available options are
 
 ```
 Options:
-  -o --output <outFile>  Name of the output sql file (default: "dump.sql")
+  -o --output <outFile>  STDOUT or name of the output sql file (default: "dump.sql")
   -h, --help             display help for command
 ```
 
 You can also use this with `npx`
 
 ```
-npx pgfaker config.js --output=dump.sql
+npx pgfaker config.js --output=STDOUT
 ```
 
 ## Configuration

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,22 +1,17 @@
-import {createWriteStream} from 'fs';
-import {join} from 'path'; import {createInterface} from 'readline';
+import {join} from 'path';
 import {ConfigurationType} from '../../types/domain.js';
 import {Parser} from '../parser/parse.js';
 import {createPgDump} from '../pg/dump.js';
 import {PgExtractor} from '../pg/extractors.js';
+import {createInputStream, createOutputStream} from '../utils/io.js';
 
 export async function cli(config: string, args: { [arg: string]: string }) {
   const importPath = join(process.cwd(), config);
   const {configuration}: { configuration: ConfigurationType } = await import(importPath);
-
   const pgDump = createPgDump(configuration.connectionUrl);
+  const inputStream = createInputStream(pgDump.stdout);
+  const outputStream: any = createOutputStream(args.output);
 
-  const inputStream = createInterface({
-    input: pgDump.stdout,
-    crlfDelay: Infinity,
-  }) as any as Iterable<string>;
-
-  const outputStream = createWriteStream(args.output);
   let canWriteToFile = true;
   const parser = new Parser(configuration);
 

--- a/src/utils/io.ts
+++ b/src/utils/io.ts
@@ -1,0 +1,17 @@
+import {createWriteStream} from 'fs';
+import {stdout} from 'process';
+import {createInterface} from 'readline';
+
+export function createInputStream(stream: any) {
+  return createInterface({
+    input: stream,
+    crlfDelay: Infinity,
+  }) as any as Iterable<string>;
+}
+
+export function createOutputStream(stream: string) {
+  if (stream === 'STDOUT') {
+    return stdout;
+  }
+  return createWriteStream(stream);
+}


### PR DESCRIPTION
## Additions

1. `--output` flag can now also accept STDOUT as output source, which will flush everything to the stdout.

    ````
    npx pgfaker config.js --output=STDOUT
    ````
2. Documentation update for the same
