### PR TITLE
Fix default transformers not working

### DIFF
--- a/fixtures/configurations/basic.ts
+++ b/fixtures/configurations/basic.ts
@@ -15,8 +15,5 @@ export function configWithUrl() {
 export function emptyAOO(): AbstractOperationType {
   return {
     aoo: {},
-    flags: {
-      optimizeQuerySearch: true,
-    },
   };
 }

--- a/fixtures/configurations/complete.ts
+++ b/fixtures/configurations/complete.ts
@@ -26,7 +26,6 @@ export function completeConfiguration() {
 
   const configurationParsed = {
     aoo: expectedAoo,
-    flags: {optimizeQuerySearch: false},
   };
 
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pgfaker",
-  "version": "2.0.1",
+  "version": "2.0.2-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pgfaker",
-      "version": "2.0.1",
+      "version": "2.0.2-beta.1",
       "license": "ISC",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgfaker",
-  "version": "2.0.1",
+  "version": "2.0.2-beta.1",
   "description": "Tool for dumping/exporting your postgres database's table data with custom masking rules.",
   "main": "./lib/src/index.js",
   "type": "module",

--- a/src/cli/__tests__/parser.spec.ts
+++ b/src/cli/__tests__/parser.spec.ts
@@ -33,9 +33,6 @@ describe('Parser', () => {
     };
     const expectedAoo: AbstractOperationType = {
       aoo: {tables: optionParsed()},
-      flags: {
-        optimizeQuerySearch: false,
-      },
     };
 
     const aoo = parser.parse(configuration);
@@ -51,9 +48,6 @@ describe('Parser', () => {
     };
     const expectedAoo: AbstractOperationType = {
       aoo: {columns: configuration.columns},
-      flags: {
-        optimizeQuerySearch: true,
-      },
     };
 
     const aoo = parser.parse(configuration);
@@ -69,9 +63,21 @@ describe('Parser', () => {
     };
     const expectedAoo: AbstractOperationType = {
       aoo: {tables: configuration.tables},
-      flags: {
-        optimizeQuerySearch: true,
-      },
+    };
+
+    const aoo = parser.parse(configuration);
+
+    expect(aoo).toEqual(expectedAoo);
+  });
+
+  it('returns correct abstraction object if only default transformer is defined ', () => {
+    const parser = new Parser();
+    const configuration: ConfigurationType = {
+      ...configWithUrl(),
+      defaultTransformer: (val: string) => val,
+    };
+    const expectedAoo: AbstractOperationType = {
+      aoo: {defaultTransformer: configuration.defaultTransformer},
     };
 
     const aoo = parser.parse(configuration);

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -50,7 +50,7 @@ class Parser {
   }
 
   parse(configuration: ConfigurationType): AbstractOperationType {
-    const {tables, columns, options} = configuration;
+    const {tables, columns, options, defaultTransformer} = configuration;
     let parsedTables: TableTypes | __TableOperationType | undefined = tables;
 
     this.validate(configuration);
@@ -59,18 +59,11 @@ class Parser {
       parsedTables = this.parseOptions(tables ?? {}, options);
     }
 
-    /*
-        Queries are now matched with regex. Queries other than DataQuery are not required
-        unless options are used. This can be used to speed up the execution
-    */
-
     return {
       aoo: {
         ...(parsedTables && {tables: parsedTables}),
         ...(columns && {columns: columns}),
-      },
-      flags: {
-        optimizeQuerySearch: !options,
+        ...(defaultTransformer && {defaultTransformer: defaultTransformer}),
       },
     };
   }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -38,7 +38,7 @@ class Logger {
   }
 
   skipTableFromMasking(table: string) {
-    this.#log(`\nSkipped masking rules for: ${chalk.yellow(table)}`, VerbosityLevel.info);
+    this.#log(`Skipping masking rules for: ${chalk.yellow(table)}`, VerbosityLevel.info);
   }
 
   skippedColumns(columns: string[]) {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -26,7 +26,7 @@ class Logger {
   }
 
   complete() {
-    this.#log(chalk.blue(`Dump Complete`), VerbosityLevel.info);
+    this.#log(chalk.blue(`\nDump Complete`), VerbosityLevel.info);
   }
 
   currentTable(tableName: string) {

--- a/types/domain.ts
+++ b/types/domain.ts
@@ -44,9 +44,7 @@ export interface AbstractOperationType {
   aoo: {
     tables?: __TableOperationType;
     columns?: ColumnTypes;
-  };
-  flags: {
-    optimizeQuerySearch: boolean;
+    defaultTransformer?: TransformerType;
   };
 }
 


### PR DESCRIPTION
# Description

Default transformers were ignored due after the recent release. This is fixed in this PR. An additional bug of queries being skipped is also fixed in this PR. 

Fixes #49 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit tests 
- [x] Private E2E test repository for testing generation of dumps

**Test Configuration**:
* OS: Macos
* Node version: 18.3
* Postgres Version: 14

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - `NA`
- [x] My changes generate no new warnings
- [x] I have added tests to cover these code changes
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have verified the generated SQL is correct

