### PR TITLE
Add support for middlewares

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -135,6 +135,58 @@ export const configuration = {
 
       will make sure that the dumped sql doesn't have any queries related to users table. This will override any other masking rules specified for this table.
 
+## Advanced
+
+If you need more flexibility with masking, such as conditional masking you can use middleware.
+
+### Middleware
+
+Middleware in pgfaker allows you to access the record that is about to get transformed. You can modify the records here, or avoid the masking that is about to happen.
+
+The api looks like this
+
+```js
+export const configuration = {
+  connectionUrl: 'postgresql://USER:PASSWORD@HOST:PORT/DATABASE',
+
+  columns: {
+    description: (value) => 'This will not be used',
+  },
+
+  tables: {
+    users: [checkIfAdmin, maskingRules],
+  },
+};
+```
+
+Where `checkIfAdmin` is your middleware function and `maskingRules` is your regular object of transformers
+
+1. The `checkIfAdmin` function will receive the column values as first parameter and column names as the seconds
+
+   ```js
+   const checkIfAdmin = (columnValues, columnNames) => {
+     adminColumnIndex = columnNames.indexOf('admin');
+     isAdmin = columnValues[adminColumnIndex];
+
+     if (isAdmin === 1) {
+       return null;
+     }
+     return columnValues;
+   };
+   ```
+
+   Returning null (or any falsy value) from this function will result in any masking defined (read next point) for it to be avoided.
+
+2. The `maskingRules` is your regular object of transformers. This can be used if you want to regular way of defining transformers along with the middleware. Note that the `columns` transformers are also used here
+
+   ```js
+   const maskingRules = {
+     users: {
+       flag: (value) => 'off',
+     },
+   };
+   ```
+
 ## TroubleShooting
 
 Please refer and raise the issues on [github](https://github.com/imanpalsingh/pg-faker/issues).

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -137,13 +137,11 @@ export const configuration = {
 
 ## Advanced
 
-If you need more flexibility with masking, such as conditional masking you can use middleware.
+If you need more flexibility with masking, such as conditional masking then you can use middleware.
 
 ### Middleware
 
-Middleware in pgfaker allows you to access the record that is about to get transformed. You can modify the records here, or avoid the masking that is about to happen.
-
-The api looks like this
+Middleware in pgfaker allows you to access the record that is about to get transformed. You can modify the records here, or avoid the masking that is about to happen. The api looks like this
 
 ```js
 export const configuration = {
@@ -168,7 +166,7 @@ Where `checkIfAdmin` is your middleware function and `maskingRules` is your regu
      adminColumnIndex = columnNames.indexOf('admin');
      isAdmin = columnValues[adminColumnIndex];
 
-     if (isAdmin === 1) {
+     if (isAdmin === '1') {
        return null;
      }
      return columnValues;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pgfaker",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pgfaker",
-      "version": "2.1.0-beta.0",
+      "version": "2.1.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pgfaker",
-  "version": "2.0.2",
+  "version": "2.1.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pgfaker",
-      "version": "2.0.2-beta.1",
+      "version": "2.1.0-beta.0",
       "license": "ISC",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgfaker",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-beta.1",
   "description": "Tool for dumping/exporting your postgres database's table data with custom masking rules.",
   "main": "./lib/src/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgfaker",
-  "version": "2.0.2",
+  "version": "2.1.0-beta.0",
   "description": "Tool for dumping/exporting your postgres database's table data with custom masking rules.",
   "main": "./lib/src/index.js",
   "type": "module",

--- a/src/cli/__tests__/driver.spec.ts
+++ b/src/cli/__tests__/driver.spec.ts
@@ -9,8 +9,8 @@ describe('Driver', () => {
 
   it('raises an error and exits on missing configuration', async () => {
     const driver = new Driver();
-    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-    await driver.loadConfiguration('fixtures/imports/incorrect-config.js');
-    expect(mockExit).toBeCalled();
+    expect(async () => {
+      await driver.loadConfiguration('fixtures/imports/incorrect-config.js');
+    }).rejects.toThrowError();
   });
 });

--- a/src/cli/__tests__/parser.spec.ts
+++ b/src/cli/__tests__/parser.spec.ts
@@ -12,11 +12,11 @@ import {AbstractOperationType, ConfigurationType} from '../../../types/domain';
 import {Parser} from '../parser';
 
 describe('Parser', () => {
-  it('exits the process if connectionUrl is missing', () => {
-    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  it('throws error if connectionUrl is missing', () => {
     const parser = new Parser();
-    parser.parse(minimalConfiguration());
-    expect(mockExit).toBeCalled();
+    expect(() => {
+      parser.parse(minimalConfiguration());
+    }).toThrowError();
   });
 
   it('returns empty abstraction object if no  rule are defined in configuration ', () => {

--- a/src/cli/driver.ts
+++ b/src/cli/driver.ts
@@ -12,7 +12,7 @@ class Driver {
     const importPath = join(process.cwd(), path);
     const {configuration}: {configuration: ConfigurationType} = await import(importPath);
     if (!configuration) {
-      gracefulShutdown(
+      throw new Error(
         // eslint-disable-next-line max-len
         `Configuration could not be found in ${importPath}. Make sure the js file exports object named 'configuration' `,
       );

--- a/src/cli/engine.ts
+++ b/src/cli/engine.ts
@@ -110,7 +110,11 @@ class Engine {
 
       if (Array.isArray(tableOperations)) {
         const [middleware, transforms] = tableOperations;
-        this.cache.transformers = [middleware, {...transforms, ...this.aoo.columns}];
+        const requiredTransformers = this.#requiredTransformers({
+          ...transforms,
+          ...this.aoo.columns,
+        });
+        this.cache.transformers = [middleware, requiredTransformers || {}];
       } else {
         tableOperations = {...(tableOperations as ColumnTypes), ...this.aoo.columns};
         this.cache.transformers = this.#requiredTransformers(tableOperations);

--- a/src/cli/engine.ts
+++ b/src/cli/engine.ts
@@ -96,6 +96,7 @@ class Engine {
       this.logger.currentTable(query.tableName);
       this.cache.columns = query.columns;
       let tableOperations = this.aoo.tables?.[this.cache.tableName];
+
       if (Array.isArray(tableOperations)) {
         const [middleware, transforms] = tableOperations;
         this.cache.transformers = [middleware, {...transforms, ...this.aoo.columns}];

--- a/src/cli/engine.ts
+++ b/src/cli/engine.ts
@@ -142,7 +142,11 @@ class Engine {
     if (Array.isArray(transformers)) {
       const [middleware, mapping] = transformers;
       const passedRecord = middleware(record, columns!);
-      maskedData = this.#declarativeTransformation(passedRecord, mapping);
+      if (passedRecord) {
+        maskedData = this.#declarativeTransformation(passedRecord, mapping);
+      } else {
+        maskedData = record;
+      }
     } else {
       maskedData = this.#declarativeTransformation(record, transformers!);
     }

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -5,14 +5,12 @@ import {
   TableTypes,
   __TableOperationType,
 } from '../../types/domain.js';
-import {gracefulShutdown} from '../utils/handlers.js';
 import {Logger} from '../utils/logger.js';
 
 class Parser {
   validate(configuration: ConfigurationType) {
     if (!configuration.connectionUrl) {
-      gracefulShutdown('connectionUrl is missing, cannot connect to database without it');
-      return;
+      throw new Error('connectionUrl is missing, cannot connect to database without it');
     }
   }
 
@@ -42,7 +40,7 @@ class Parser {
           parsedTables[table] = 'SKIP:OUTPUT';
           break;
         default:
-          gracefulShutdown(`Unrecognized skipping method ${skipType}`);
+          throw new Error(`Unrecognized skipping method ${skipType}`);
       }
     }
 

--- a/src/pg/queries/index.ts
+++ b/src/pg/queries/index.ts
@@ -14,15 +14,10 @@ import setQ from './set-q.js';
 import select from './select.js';
 import createIndex from './create-index.js';
 
-export const queries = [
-  alterSequence,
-  alterTableSequence,
-  alterTable,
-  copy,
-  createSequence,
-  createTable,
-  sequenceSet,
-  setQ,
-  select,
-  createIndex,
-];
+export const indexOnQueries = {
+  SET: [setQ],
+  SELECT: [sequenceSet, select],
+  CREATE: [createSequence, createTable, createIndex],
+  ALTER: [alterSequence, alterTableSequence, alterTable],
+  COPY: [copy],
+};

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -42,7 +42,7 @@ class Logger {
   }
 
   skippedColumns(columns: string[]) {
-    this.#log(`Skipping Columns: ${chalk.yellow(columns)}`, VerbosityLevel.verbose);
+    this.#log(`Skipping Columns: ${chalk.red(columns)}`, VerbosityLevel.verbose);
   }
 
   transformedColumns(columns: string[]) {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -54,7 +54,7 @@ class Logger {
   }
 
   static error(value: string) {
-    console.error(chalk.red(`ERROR: ${value}`));
+    console.error(chalk.red(`${value}`));
   }
 
   static warn(value: string) {

--- a/types/domain.ts
+++ b/types/domain.ts
@@ -4,16 +4,20 @@ import {Query} from '../src/pg/queries/abstracts/query';
 // eslint-disable-next-line no-unused-vars
 export type TransformerType = (value: any) => any;
 
+export type CommonTransformerType = (records: string[], columns: string[]) => string[];
+
 export type Operation = 'SKIP:MASK' | 'SKIP:OUTPUT';
 
 export interface TableTypes {
-  [table_name: string]: {
-    [column_name: string]: TransformerType;
-  };
+  [table_name: string]:
+    | {
+        [column_name: string]: TransformerType;
+      }
+    | TransformerType;
 }
 
 export interface __TableOperationType {
-  [table_name: string]: Operation | ColumnTypes;
+  [table_name: string]: Operation | ColumnTypes | CommonTransformerType;
 }
 
 export interface ColumnTypes {
@@ -55,5 +59,5 @@ export interface WriteableStream {
 export interface EngineCache {
   tableName: string;
   columns?: Array<string>;
-  transformers?: ColumnTypes | null;
+  transformers?: ColumnTypes | CommonTransformerType | null;
 }

--- a/types/domain.ts
+++ b/types/domain.ts
@@ -4,7 +4,9 @@ import {Query} from '../src/pg/queries/abstracts/query';
 // eslint-disable-next-line no-unused-vars
 export type TransformerType = (value: any) => any;
 
-export type CommonTransformerType = (records: string[], columns: string[]) => string[];
+export type Middleware = (records: string[], columns: string[]) => string[];
+
+export type ExecuterInstructions = [Middleware, ColumnTypes];
 
 export type Operation = 'SKIP:MASK' | 'SKIP:OUTPUT';
 
@@ -13,11 +15,11 @@ export interface TableTypes {
     | {
         [column_name: string]: TransformerType;
       }
-    | TransformerType;
+    | ExecuterInstructions;
 }
 
 export interface __TableOperationType {
-  [table_name: string]: Operation | ColumnTypes | CommonTransformerType;
+  [table_name: string]: Operation | ColumnTypes | ExecuterInstructions;
 }
 
 export interface ColumnTypes {
@@ -59,5 +61,5 @@ export interface WriteableStream {
 export interface EngineCache {
   tableName: string;
   columns?: Array<string>;
-  transformers?: ColumnTypes | CommonTransformerType | null;
+  transformers?: ColumnTypes | ExecuterInstructions | null;
 }


### PR DESCRIPTION
# Description

To allow more flexibility in doing transform, this PR adds a feature to allow middleware. The middleware will receive entire row of record before each column is individually masked. This can help in conditional masking, and more flexibility.

The api can used as

```
tables : {
  users: [middleware, transformers]
}
```

This is explained in the documentation.

Note that this is not a breaking change and the original method of defining transformers for tables is also going to work and can be used interchangeably.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Verified on a private e2e test repository

**Test Configuration**:
* OS: macos
* Node version: 18.3.0
* Postgres Version: 14

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to cover these code changes - `Not covered`
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have verified the generated SQL is correct

